### PR TITLE
fix: Fixed URL of markdown

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -69,7 +69,7 @@ def main():
 
     # Find out more section
     with st.expander("En savoir plus sur notre démarche de construction d'un dataset collaboratif"):
-        st.markdown(Path("/src/static/find-out-more.md").read_text())
+        st.markdown(Path("src/static/find-out-more.md").read_text())
 
     if submitted:
 


### PR DESCRIPTION
This PR fixes the path to "find out more" markdown. I wasn't able to run the demo without getting an error before.
Now everything seems alright!